### PR TITLE
Use the color variable for the footer links

### DIFF
--- a/includes/_append.fragment-footer.html
+++ b/includes/_append.fragment-footer.html
@@ -1,4 +1,3 @@
-                 | <a style="color: #81BEF7" target="_blank" href="{{site.data.fhir.canonical}}/history.html">Version History</a> |
-                 <a style="color: #81BEF7" rel="license" href="{{site.data.fhir.path}}license.html"><img style="border-style: none;" alt="CC0" src="cc0.png"/></a> |
-                 <!--<a style="color: #81BEF7" href="todo.html">Search</a> | --> 
-                 <a style="color: #81BEF7" target="_blank" href="http://hl7.org/fhir-issues">Propose a change</a>
+                 | <a style="color: var(--footer-hyperlink-text-color)" target="_blank" href="{{site.data.fhir.canonical}}/history.html">Version History</a> |
+                 <a style="color: var(--footer-hyperlink-text-color)" rel="license" href="{{site.data.fhir.path}}license.html"><img style="border-style: none;" alt="CC0" src="cc0.png"/></a> |
+                 <a style="color: var(--footer-hyperlink-text-color)" target="_blank" href="http://hl7.org/fhir-issues">Propose a change</a>


### PR DESCRIPTION
Use the standard variable for link color that all the IGs use from the base template (rather than an explicit value)
_This also means that the color can be over-ridden in a template if desired too and be consistent_

(and remove the commented out search block)